### PR TITLE
Show category names instead of file names in photo grid

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -167,7 +167,7 @@ function renderPhotoGrid() {
     return `
       <div class="photo-card loading" data-file="${photo.file}" data-box="${photo.box}" data-category="${photo.category}" data-drive-id="${photo.driveId || ''}">
         <img src="" alt="Box ${photo.box} view ${photo.view}" loading="lazy" data-drive-id="${photo.driveId || ''}">
-        <div class="label">${photo.file}</div>
+        <div class="label">${photo.category || `Box ${photo.box}`}</div>
       </div>
     `;
   }).join('');


### PR DESCRIPTION
Display descriptive category names like "Nail Guns & Fasteners" instead of technical file names like "1a.jpg" in the Browse Photos grid labels.